### PR TITLE
Expose blocks/pointers/events to graphql

### DIFF
--- a/server/lib/schema/index.ts
+++ b/server/lib/schema/index.ts
@@ -72,35 +72,23 @@ const BlockInput = new GraphQLInputObjectType({
   fields: _.pick(attributeFields(models.Block), 'value', 'id'),
 })
 
+function modelGraphQLFields(type, model){
+  return ({
+        type,
+        args: {where: {type: GraphQLJSON}},
+        resolve: resolver(model)
+  })
+}
+
 let schema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: 'RootQueryType',
     fields: {
-      workspaces: {
-        type: new GraphQLList(workspaceType),
-        args: {where: {type: GraphQLJSON}},
-        resolve: resolver(models.Workspace)
-      },
-      workspace: {
-        type: workspaceType,
-        args: {id: {type: GraphQLString}},
-        resolve: resolver(models.Workspace)
-      },
-      blocks: {
-        type: new GraphQLList(blockType),
-        args: {where: {type: GraphQLJSON}},
-        resolve: resolver(models.Block)
-      },
-      pointers: {
-        type: new GraphQLList(pointerType),
-        args: {where: {type: GraphQLJSON}},
-        resolve: resolver(models.Pointer)
-      },
-      events: {
-        type: new GraphQLList(eventType),
-        args: {where: {type: GraphQLJSON}},
-        resolve: resolver(models.Event)
-      },
+      workspaces: modelGraphQLFields(new GraphQLList(workspaceType), models.Workspace),
+      workspace: modelGraphQLFields(workspaceType, models.Workspace),
+      blocks: modelGraphQLFields(new GraphQLList(blockType), models.Block),
+      pointers: modelGraphQLFields(new GraphQLList(pointerType), models.Pointer),
+      events: modelGraphQLFields(new GraphQLList(eventType), models.Event),
     }
   }),
   mutation: new GraphQLObjectType({


### PR DESCRIPTION
Recommended query to get all relevant data:

```graphql
query{
  workspaces{
    id
    parentId
    childWorkspaceOrder
    connectedPointers
  }
  blocks{
    id
    workspaceId
    type
    value
    cachedExportPointerValues
  }
  pointers{
    id
    sourceBlockId
  }
}
```