### PR TITLE
Fix homepage ordering of workspaces

### DIFF
--- a/client/src/pages/RootWorkspacePage/index.tsx
+++ b/client/src/pages/RootWorkspacePage/index.tsx
@@ -12,6 +12,8 @@ import { databaseJSONToValue } from "../../lib/slateParser";
 import { CREATE_ROOT_WORKSPACE, WORKSPACES_QUERY } from "../../graphqlQueries";
 import { Auth } from "../../auth";
 
+import sortWorkspacesByCreatedAt from '../../utils/sortWorkspacesByCreatedAt';
+
 import "./RootWorkspacePage.css";
 
 const RootWorkspacePageSection = styled.div`
@@ -127,10 +129,12 @@ const AuthMessage = () => {
 export class RootWorkspacePagePresentational extends React.Component<any, any> {
   public render() {
     const isLoading = this.props.originWorkspaces.loading;
-    const workspaces = _.sortBy(
-      this.props.originWorkspaces.workspaces,
-      "createdAt"
-    );
+
+    let sortedWorkspaces : Array<any> = [];
+    if (!isLoading) {
+      sortedWorkspaces = sortWorkspacesByCreatedAt(this.props.originWorkspaces.workspaces);
+    }
+
     return (
       <div>
         {!Auth.isAuthenticated() && <AuthMessage />}
@@ -139,7 +143,7 @@ export class RootWorkspacePagePresentational extends React.Component<any, any> {
           <WorkspaceList>
             {isLoading
               ? "Loading..."
-              : workspaces.map(w => <RootWorkspace workspace={w} key={w.id} />)}
+              : sortedWorkspaces.map(w => <RootWorkspace workspace={w} key={w.id} />)}
           </WorkspaceList>
         </RootWorkspacePageSection>
         {Auth.isAuthenticated() && (

--- a/client/src/pages/RootWorkspacePage/index.tsx
+++ b/client/src/pages/RootWorkspacePage/index.tsx
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { compose } from "recompose";

--- a/client/src/pages/RootWorkspacePage/index.tsx
+++ b/client/src/pages/RootWorkspacePage/index.tsx
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import * as React from "react";
 import styled from "styled-components";
 import { compose } from "recompose";
@@ -10,8 +11,6 @@ import { NewBlockForm } from "../../components/NewBlockForm";
 import { databaseJSONToValue } from "../../lib/slateParser";
 import { CREATE_ROOT_WORKSPACE, WORKSPACES_QUERY } from "../../graphqlQueries";
 import { Auth } from "../../auth";
-
-import sortWorkspacesByCreatedAt from '../../utils/sortWorkspacesByCreatedAt';
 
 import "./RootWorkspacePage.css";
 
@@ -129,10 +128,10 @@ export class RootWorkspacePagePresentational extends React.Component<any, any> {
   public render() {
     const isLoading = this.props.originWorkspaces.loading;
 
-    let sortedWorkspaces : Array<any> = [];
-    if (!isLoading) {
-      sortedWorkspaces = sortWorkspacesByCreatedAt(this.props.originWorkspaces.workspaces);
-    }
+    const workspaces = _.sortBy(
+      this.props.originWorkspaces.workspaces,
+      workspace => Date.parse(workspace.createdAt)
+    );
 
     return (
       <div>
@@ -142,7 +141,7 @@ export class RootWorkspacePagePresentational extends React.Component<any, any> {
           <WorkspaceList>
             {isLoading
               ? "Loading..."
-              : sortedWorkspaces.map(w => <RootWorkspace workspace={w} key={w.id} />)}
+              : workspaces.map(w => <RootWorkspace workspace={w} key={w.id} />)}
           </WorkspaceList>
         </RootWorkspacePageSection>
         {Auth.isAuthenticated() && (

--- a/client/src/utils/sortWorkspacesByCreatedAt.js
+++ b/client/src/utils/sortWorkspacesByCreatedAt.js
@@ -1,0 +1,3 @@
+export default function sortWorkspacesByCreatedAt(workspaces) {
+  return workspaces.concat().sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+}

--- a/client/src/utils/sortWorkspacesByCreatedAt.js
+++ b/client/src/utils/sortWorkspacesByCreatedAt.js
@@ -1,3 +1,0 @@
-export default function sortWorkspacesByCreatedAt(workspaces) {
-  return workspaces.concat().sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
-}


### PR DESCRIPTION
Previously workspaces were being ordered by _.sortBy on their createdAt
property. But createdAt was just a string, like
"Wed Jul 18 2018 21:42:56 GMT+0000 (UTC)". So these strings were being
compared alphabetically, and this order was determining the order in
which the workspaces appeared on the homepage. I made sure it was the
date itself that was being used to create the sort order. I also put
this sort function in its own file.