### PR TITLE
Prevent exports across pointer boundaries

### DIFF
--- a/client/src/slate-helpers/slate-change-mutations/insertPointerExport.ts
+++ b/client/src/slate-helpers/slate-change-mutations/insertPointerExport.ts
@@ -1,6 +1,7 @@
 import * as uuidv1 from "uuid/v1";
 import { Change } from "../../components/BlockEditor/types";
 import * as slateChangeMutations from "../../slate-helpers/slate-change-mutations";
+import { isSelectionAcrossPointers } from "../slate-utils/isSelectionAcrossPointers";
 
 const onlyOneNodeThatIsPointerExport = nodes => {
   return (
@@ -35,6 +36,14 @@ export function insertPointerExport(change: Change) {
   // pick up what comes after
   if (isNestedInPointerExport) {
     slateChangeMutations.moveSelectionAwayFromPointerEdge(change);
+  }
+
+  // disallow attempts to export across pointer boundaries
+  const selection = change.value.selection;
+  const document = change.value.document;
+  const isExportingAcrossPointers = isSelectionAcrossPointers(selection, document);
+  if (isExportingAcrossPointers) {
+    return;
   }
 
   // A Slate fragment is a document: value.fragment is the document

--- a/client/src/slate-helpers/slate-change-mutations/insertPointerExport.ts
+++ b/client/src/slate-helpers/slate-change-mutations/insertPointerExport.ts
@@ -39,9 +39,7 @@ export function insertPointerExport(change: Change) {
   }
 
   // disallow attempts to export across pointer boundaries
-  const selection = change.value.selection;
-  const document = change.value.document;
-  const isExportingAcrossPointers = isSelectionAcrossPointers(selection, document);
+  const isExportingAcrossPointers = isSelectionAcrossPointers(change.value);
   if (isExportingAcrossPointers) {
     return;
   }

--- a/client/src/slate-helpers/slate-change-mutations/normalizeChange.js
+++ b/client/src/slate-helpers/slate-change-mutations/normalizeChange.js
@@ -1,4 +1,4 @@
-import { closestPointerExportAncestor } from "../slate-utils/closestPointerExportAncestor";
+import { containingPointerExportAncestor } from "../slate-utils/containingPointerExportAncestor";
 import { hasSpacerAsFirstChar } from "../slate-utils//hasSpacerAsFirstChar";
 import { hasSpacerAsLastChar } from "../slate-utils//hasSpacerAsLastChar";
 import { isDirectlyAfterExport } from "../slate-utils//isDirectlyAfterExport";

--- a/client/src/slate-helpers/slate-utils/containingPointerExportAncestor.ts
+++ b/client/src/slate-helpers/slate-utils/containingPointerExportAncestor.ts
@@ -2,7 +2,7 @@ function isPointerExport(node: any) {
   return node.type && node.type === "pointerExport";
 }
 
-export function closestPointerExportAncestor(node: any, document: any) {
+export function containingPointerExportAncestor(node: any, document: any) {
   let curNode = node;
   while (
     !(isPointerExport(curNode))

--- a/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
+++ b/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
@@ -1,0 +1,16 @@
+import { closestPointerExportAncestor } from "./closestPointerExportAncestor";
+
+export function isSelectionAcrossPointers(selection, document) {
+  const { anchorKey, focusKey } = selection;
+  const anchorNode = document.getNode(anchorKey);
+  const focusNode = document.getNode(focusKey);
+
+  const closestPointerExportAncestorOfAnchorNode = closestPointerExportAncestor(anchorNode, document);
+  const closestPointerExportAncestorOfFocusNode = closestPointerExportAncestor(focusNode, document);
+
+  if (closestPointerExportAncestorOfAnchorNode !== closestPointerExportAncestorOfFocusNode) {
+    return true;
+  }
+
+  return false;
+}

--- a/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
+++ b/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
@@ -3,15 +3,13 @@ import { containingPointerExportAncestor } from "./containingPointerExportAncest
 export function isSelectionAcrossPointers(value) {
   const { document, selection } = value;
   const { anchorKey, focusKey } = selection;
-  const anchorNode = document.getNode(anchorKey);
-  const focusNode = document.getNode(focusKey);
 
-  const containingPointerExportAncestorOfAnchorNode = containingPointerExportAncestor(anchorNode, document);
-  const containingPointerExportAncestorOfFocusNode = containingPointerExportAncestor(focusNode, document);
+  const containingPointerExportAncestorByKey =
+    key => containingPointerExportAncestor(document.getNode(key), document);
 
-  if (containingPointerExportAncestorOfAnchorNode !== containingPointerExportAncestorOfFocusNode) {
-    return true;
-  }
-
-  return false;
+  return (
+    containingPointerExportAncestorByKey(anchorKey)
+    !==
+    containingPointerExportAncestorByKey(focusKey) 
+  );
 }

--- a/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
+++ b/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
@@ -1,6 +1,7 @@
 import { closestPointerExportAncestor } from "./closestPointerExportAncestor";
 
-export function isSelectionAcrossPointers(selection, document) {
+export function isSelectionAcrossPointers(value) {
+  const { document, selection } = value;
   const { anchorKey, focusKey } = selection;
   const anchorNode = document.getNode(anchorKey);
   const focusNode = document.getNode(focusKey);

--- a/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
+++ b/client/src/slate-helpers/slate-utils/isSelectionAcrossPointers.js
@@ -1,4 +1,4 @@
-import { closestPointerExportAncestor } from "./closestPointerExportAncestor";
+import { containingPointerExportAncestor } from "./containingPointerExportAncestor";
 
 export function isSelectionAcrossPointers(value) {
   const { document, selection } = value;
@@ -6,10 +6,10 @@ export function isSelectionAcrossPointers(value) {
   const anchorNode = document.getNode(anchorKey);
   const focusNode = document.getNode(focusKey);
 
-  const closestPointerExportAncestorOfAnchorNode = closestPointerExportAncestor(anchorNode, document);
-  const closestPointerExportAncestorOfFocusNode = closestPointerExportAncestor(focusNode, document);
+  const containingPointerExportAncestorOfAnchorNode = containingPointerExportAncestor(anchorNode, document);
+  const containingPointerExportAncestorOfFocusNode = containingPointerExportAncestor(focusNode, document);
 
-  if (closestPointerExportAncestorOfAnchorNode !== closestPointerExportAncestorOfFocusNode) {
+  if (containingPointerExportAncestorOfAnchorNode !== containingPointerExportAncestorOfFocusNode) {
     return true;
   }
 


### PR DESCRIPTION
This change prevents attempts to export across pointer boundaries. This should eliminate the split pointer bug, where sometimes the same pointer would get split up into multiple parts.