### PR TITLE
Allow multi-paragraph copy-paste

### DIFF
--- a/client/src/lib/slateParser.ts
+++ b/client/src/lib/slateParser.ts
@@ -1,7 +1,7 @@
 import Plain from "slate-plain-serializer";
 
 export function valueToDatabaseJSON(value: any) {
-  return JSON.stringify(value.toJSON().document.nodes[0]);
+  return JSON.stringify(value.toJSON().document.nodes);
 }
 
 export function databaseJSONToValue(databaseJson: any) {
@@ -11,7 +11,7 @@ export function databaseJSONToValue(databaseJson: any) {
       document: {
         object: "document",
         data: {},
-        nodes: [databaseJson]
+        nodes: [].concat(databaseJson),
       }
     };
   } else {

--- a/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
+++ b/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
@@ -1,22 +1,5 @@
+import { getInlinesAsArray } from "../slate-utils/getInlinesAsArray";
 import { Change } from "../../components/BlockEditor/types";
-
-function getInlinesAsArray(node: any) {
-  let array: any = [];
-
-  node.nodes.forEach(child => {
-    if (child.object === "text") {
-      return;
-    }
-    if (child.object === "inline") {
-      array.push(child);
-    }
-    if (!child.isLeafInline()) {
-      array = array.concat(getInlinesAsArray(child));
-    }
-  });
-
-  return array;
-}
 
 export function removePointerExport(change: Change, hoveredItem: any) {
   const value = change.value;

--- a/client/src/slate-helpers/slate-utils/getInlinesAsArray.ts
+++ b/client/src/slate-helpers/slate-utils/getInlinesAsArray.ts
@@ -1,6 +1,4 @@
-import * as _ from "lodash";
-
-export const getAllInlinesAsArray = nodeOrNodes => {
+export function getInlinesAsArray(nodeOrNodes: any) {
   let array: any = [];
 
   let nodes;
@@ -17,8 +15,8 @@ export const getAllInlinesAsArray = nodeOrNodes => {
     if (child.object === "inline") {
       array.push(child);
     }
-    if (_.has(child, "nodes")) {
-      array = array.concat(getAllInlinesAsArray(child));
+    if (!child.isLeafInline()) {
+      array = array.concat(getInlinesAsArray(child));
     }
   });
 


### PR DESCRIPTION
Previously, when copy-pasting multiple paragraphs, only the first
paragraph would get saved to the server. This was because the app
assumed each Slate document had only one block child. I generalized
so that this assumption is no longer made. Now a Slate document might
have a single block node as a child, or many. I also refactored
minimally by moving the client-side getAllInlinesAsArray into its own
file.