### PR TITLE
Remove unneeded buttons

### DIFF
--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -135,8 +135,6 @@ export class BlockEditorEditingPresentational extends React.Component<
       <BlockEditorStyle>
         <MenuBar
           blockEditor={this.props.blockEditor}
-          onAddPointerImport={this.onAddPointerImport}
-          availablePointers={this.props.availablePointers}
           mutationStatus={this.props.mutationStatus}
           hasChangedSinceDatabaseSave={this.state.hasChangedSinceDatabaseSave}
         />
@@ -256,13 +254,6 @@ export class BlockEditorEditingPresentational extends React.Component<
 
   private updateEditor = (input: any) => {
     this.editor = input;
-  };
-
-  private onAddPointerImport = (pointerId: string) => {
-    const { value } = this.props.value
-      .change()
-      .insertInline(inlinePointerImportJSON(pointerId));
-    this.onChange(value, true);
   };
 
   private considerSaveToDatabase = () => {

--- a/client/src/components/BlockEditor/MenuBar.tsx
+++ b/client/src/components/BlockEditor/MenuBar.tsx
@@ -1,13 +1,10 @@
 import * as React from "react";
 import styled from "styled-components";
-import { DropdownButton, MenuItem } from "react-bootstrap";
 import FontAwesomeIcon = require("@fortawesome/react-fontawesome");
 import faSpinner = require("@fortawesome/fontawesome-free-solid/faSpinner");
 import faCheck = require("@fortawesome/fontawesome-free-solid/faCheck");
 import faExclamationTriangle = require("@fortawesome/fontawesome-free-solid/faExclamationTriangle");
 import { MutationStatus } from "./types";
-import { ShowExpandedPointer } from "../../lib/slate-pointers/ShowExpandedPointer";
-import * as _ from "lodash";
 
 const SavingIconStyle = styled.span`
   float: right;
@@ -15,55 +12,6 @@ const SavingIconStyle = styled.span`
   font-size: 0.8em;
   margin-top: 1px;
 `;
-
-interface PointerDropdownMenuProps {
-  availablePointers: any[];
-  blockEditor: any;
-  onAddPointerImport(pointerId: string): () => {};
-}
-
-export class PointerDropdownMenu extends React.Component<
-  PointerDropdownMenuProps
-> {
-  public shouldComponentUpdate(newProps: any, newState: any) {
-    if (!_.isEqual(newProps.availablePointers, this.props.availablePointers)) {
-      return true;
-    }
-    return false;
-  }
-
-  public render() {
-    return (
-      <DropdownButton
-        title="Import"
-        id="bg-nested-dropdown"
-        bsSize={"xsmall"}
-        style={{ marginBottom: "5px", marginRight: "5px" }}
-        tabIndex={-1}
-      >
-        {this.props.availablePointers.map((e: any, index: number) => (
-          <MenuItem
-            eventKey="1"
-            key={index}
-            onClick={event => {
-              this.props.onAddPointerImport(e.data.pointerId);
-            }}
-          >
-            <span>
-              {`$${index + 1} - ${e.data.pointerId.slice(0, 5)}`}
-              <ShowExpandedPointer
-                exportingPointer={e}
-                availablePointers={this.props.availablePointers}
-                blockEditor={this.props.blockEditor}
-                isHoverable={false}
-              />
-            </span>
-          </MenuItem>
-        ))}
-      </DropdownButton>
-    );
-  }
-}
 
 const Icons = {
   [MutationStatus.NotStarted]: null,
@@ -104,18 +52,11 @@ const SavingIcon = ({
 };
 
 export const MenuBar = ({
-  onAddPointerImport,
-  availablePointers,
   mutationStatus,
   hasChangedSinceDatabaseSave,
   blockEditor
 }) => (
   <div>
-    <PointerDropdownMenu
-      onAddPointerImport={onAddPointerImport}
-      availablePointers={availablePointers}
-      blockEditor={blockEditor}
-    />
     <SavingIcon
       hasChangedSinceDatabaseSave={hasChangedSinceDatabaseSave}
       mutationStatus={mutationStatus}

--- a/client/src/components/BlockHoverMenu/Menu.tsx
+++ b/client/src/components/BlockHoverMenu/Menu.tsx
@@ -29,27 +29,6 @@ const HoverButton = ({ children, onClick }) => (
   </HoverBackground>
 );
 
-const ImportedPointerMenu = props => {
-  const {
-    blockEditor: {
-      hoveredItem: { id },
-      pointerReferences
-    },
-    onChangePointerReference
-  } = props;
-  const reference = pointerReferences[id];
-  const isOpen = reference && reference.isOpen;
-  return (
-    <HoverButton
-      onClick={() =>
-        onChangePointerReference({ id, reference: { isOpen: !isOpen } })
-      }
-    >
-      {isOpen ? "Close" : "Expand"}
-    </HoverButton>
-  );
-};
-
 const ExportedPointerMenu = ({ removeExportOfSelection }) => (
   <HoverButton onClick={removeExportOfSelection}>Remove Pointer</HoverButton>
 );
@@ -76,12 +55,6 @@ export class MenuPresentational extends React.Component<any> {
             {hoverItemType === HOVER_ITEM_TYPES.SELECTED_TEXT && (
               <ExportSelectionMenu
                 exportSelection={this.props.exportSelection}
-              />
-            )}
-            {hoverItemType === HOVER_ITEM_TYPES.POINTER_IMPORT && (
-              <ImportedPointerMenu
-                blockEditor={this.props.blockEditor}
-                onChangePointerReference={this.props.changePointerReference}
               />
             )}
             {hoverItemType === HOVER_ITEM_TYPES.POINTER_EXPORT &&

--- a/client/src/components/BlockHoverMenu/Menu.tsx
+++ b/client/src/components/BlockHoverMenu/Menu.tsx
@@ -7,8 +7,6 @@ import { Button } from "react-bootstrap";
 import { compose } from "recompose";
 import { connect } from "react-redux";
 import {
-  changePointerReference,
-  exportSelection,
   removeExportOfSelection,
   HOVER_ITEM_TYPES
 } from "../../modules/blockEditor/actions";
@@ -65,6 +63,6 @@ export class MenuPresentational extends React.Component<any> {
 export const Menu: any = compose(
   connect(
     ({ blockEditor }) => ({ blockEditor }),
-    { changePointerReference, exportSelection, removeExportOfSelection }
+    { removeExportOfSelection }
   )
 )(MenuPresentational);

--- a/client/src/components/BlockHoverMenu/Menu.tsx
+++ b/client/src/components/BlockHoverMenu/Menu.tsx
@@ -33,10 +33,6 @@ const ExportedPointerMenu = ({ removeExportOfSelection }) => (
   <HoverButton onClick={removeExportOfSelection}>Remove Pointer</HoverButton>
 );
 
-const ExportSelectionMenu = ({ exportSelection }) => (
-  <HoverButton onClick={exportSelection}>Export</HoverButton>
-);
-
 export class MenuPresentational extends React.Component<any> {
   public constructor(props: any) {
     super(props);
@@ -52,11 +48,6 @@ export class MenuPresentational extends React.Component<any> {
       <div className="menu hover-menu" ref={this.props.menuRef} id="hover-menu">
         {blockEditor && (
           <div>
-            {hoverItemType === HOVER_ITEM_TYPES.SELECTED_TEXT && (
-              <ExportSelectionMenu
-                exportSelection={this.props.exportSelection}
-              />
-            )}
             {hoverItemType === HOVER_ITEM_TYPES.POINTER_EXPORT &&
               !readOnly && (
                 <ExportedPointerMenu


### PR DESCRIPTION
This PR removes the hover buttons for exporting a pointer, and for opening and closing an import. It also removes the import pointer dropdown.