### PR TITLE
Save pre-auth URL and redirect after login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -105,7 +105,8 @@ const Routes = () => (
       render={props => {
         if (/access_token|error/.test(props.location.hash)) {
           Auth.handleAuthentication(() => {
-            location.reload();
+            location.assign(Auth.getPreAuthUrl());
+            Auth.clearPreAuthUrl();
           });
         }
         return <Redirect to="/" />;

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -3,6 +3,8 @@ import * as auth0 from "auth0-js";
 // May consider alternate architecture ie through the redux-localstorage package
 import { Config } from "./config";
 
+const MOSAIC_PRE_AUTH_URL = "MOSAIC_PRE_AUTH_URL";
+
 export class Auth {
   public static auth0 = new auth0.WebAuth({
     domain: "mosaicapp.auth0.com",
@@ -14,7 +16,20 @@ export class Auth {
   });
 
   public static login(): void {
+    Auth.savePreAuthUrl();
     Auth.auth0.authorize();
+  }
+
+  public static savePreAuthUrl(): void {
+    localStorage.setItem(MOSAIC_PRE_AUTH_URL, window.location.href);
+  }
+
+  public static getPreAuthUrl(): string {
+    return localStorage.getItem(MOSAIC_PRE_AUTH_URL) || window.location.href;
+  }
+
+  public static clearPreAuthUrl(): void {
+    localStorage.removeItem(MOSAIC_PRE_AUTH_URL);
   }
 
   public static logout(): void {


### PR DESCRIPTION
Now when a user logs in while viewing a workspace, they are redirected back to that workspace after authentication (as opposed to being redirected to the home page). 

Also, this resolves a bug in Firefox where sometimes after logging out the page would get stuck reloading `/authCallback` over and over again.