### PR TITLE
Change how to decide whether to show "Loading..."

### DIFF
--- a/client/src/pages/EpisodeShowPage/index.tsx
+++ b/client/src/pages/EpisodeShowPage/index.tsx
@@ -184,10 +184,12 @@ export class FormPagePresentational extends React.Component<any, any> {
   }
 
   public render() {
-    const workspace = this.props.workspace.workspace;
-    if (!workspace) {
-      return <div> Loading </div>;
+    const isLoading = this.props.workspace.loading;
+    if (isLoading) {
+      return <div>Loading...</div>;
     }
+
+    const workspace = this.props.workspace.workspace;
 
     const importedPointers = workspace.connectedPointers;
 


### PR DESCRIPTION
When viewing a single workspace, clicking on the "Parent" button causes
`workspace.loading` to equal true, but doesn't get rid of
`workspace.workspace`. So the previous approach would have the old
workspace on the screen until the new  workspace fully loaded. For
workspaces that take a while to load, this would result in 5+ seconds
of nothing happening, leading a typical user to think their clicking
the "Parent" button didn't do anything. But if you tie the presentation
of the "Loading..." message to whether `workspace.loading` equals true,
then the "Loading..." messages replaces the old workspace immediately
when the user presses the "Parent" button.