### PR TITLE
Convert multi-paragraph copy-pastes into inlines

### DIFF
--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -233,6 +233,19 @@ export class BlockEditorEditingPresentational extends React.Component<
     // so this lives here instead
     slateChangeMutations.adjustCursorIfAtEdge(c);
 
+    // make sure no two blocks are side by side
+    // assumes blocks are on same level
+    // after we update Slate, can redo this very elegantly as a schema
+    let blocks = c.value.document.getBlocks();
+    while (blocks.size > 2) {
+      const firstBlock = blocks.get(0);
+      const secondBlock = blocks.get(1);
+      const firstText = secondBlock.getFirstText();
+      c.insertTextByKey(firstText.key, 0, '\n');
+      c.mergeNodeByKey(secondBlock.key);
+      blocks = c.value.document.getBlocks();
+    } 
+
     this.onChange(c.value);
   };
 

--- a/client/src/components/BlockEditor/types.tsx
+++ b/client/src/components/BlockEditor/types.tsx
@@ -11,6 +11,7 @@ export interface Change {
   collapseToStart(): Change;
   insertInline(inlineOrProperties: any): Change;
   insertTextByKey(key: any, offset: number, text: string): Change;
+  mergeNodeByKey(key: string): Change;
   move(n: number): Change;
   moveAnchor(n: number): Change;
   moveAnchorToEndOfPreviousText(): Change;


### PR DESCRIPTION
This fixes a bug where copy-pasting multi-paragraph content into a
pointer would result in only the first paragraph getting pasted.
After upgrading Slate, I plan to look into making this into a Slate
plugin/schema.