### PR TITLE
Add pointer removal on Cmd-R

### DIFF
--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -175,7 +175,7 @@ export class BlockEditorEditingPresentational extends React.Component<
   };
 
   private onKeyDown = (event: any, change: Change) => {
-    const pressedControlAndE = _event => _event.metaKey && _event.key === "e";
+    const pressedControlAndE = _event => _event.ctrlKey && _event.key === "e";
     if (pressedControlAndE(event)) {
       this.props.exportSelection(this.props.block.id);
       event.preventDefault();

--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -9,7 +9,7 @@ import { updateBlock } from "../../modules/blocks/actions";
 import { MenuBar } from "./MenuBar";
 import { MutationStatus } from "./types";
 import { valueToDatabaseJSON } from "../../lib/slateParser";
-import { exportSelection } from "../../modules/blockEditor/actions";
+import { exportSelection, removeExportOfSelection } from "../../modules/blockEditor/actions";
 import * as _ from "lodash";
 import { UPDATE_BLOCKS } from "../../graphqlQueries";
 import { Change } from "./types";
@@ -57,7 +57,8 @@ interface BlockEditorEditingPresentationalProps {
   updateBlock(value: any): () => {};
   onChange(value: any): () => boolean;
   saveBlocksMutation(): () => {};
-  exportSelection(): () => {};
+  exportSelection(blockId?: string): () => {};
+  removeExportOfSelection(blockId?: string): void;
   onKeyDown(event: any): () => {};
 }
 
@@ -176,9 +177,16 @@ export class BlockEditorEditingPresentational extends React.Component<
   private onKeyDown = (event: any, change: Change) => {
     const pressedControlAndE = _event => _event.metaKey && _event.key === "e";
     if (pressedControlAndE(event)) {
-      this.props.exportSelection();
+      this.props.exportSelection(this.props.block.id);
       event.preventDefault();
     }
+
+    const pressedControlAndR = _event => _event.metaKey && _event.key === "r";
+    if (pressedControlAndR(event)) {
+      this.props.removeExportOfSelection(this.props.block.id);
+      event.preventDefault();
+    }
+
     this.checkAutocomplete(event);
     if (!!this.props.onKeyDown) {
       this.props.onKeyDown(event);
@@ -295,7 +303,7 @@ function mapStateToProps(state: any) {
 export const BlockEditorEditing: any = compose(
   connect(
     mapStateToProps,
-    { updateBlock, exportSelection },
+    { updateBlock, exportSelection, removeExportOfSelection },
     null,
     { withRef: true }
   ),

--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -175,14 +175,14 @@ export class BlockEditorEditingPresentational extends React.Component<
   };
 
   private onKeyDown = (event: any, change: Change) => {
-    const pressedControlAndE = _event => _event.ctrlKey && _event.key === "e";
-    if (pressedControlAndE(event)) {
+    const pressedMetaAndE = _event => _event.metaKey && _event.key === "e";
+    if (pressedMetaAndE(event)) {
       this.props.exportSelection(this.props.block.id);
       event.preventDefault();
     }
 
-    const pressedControlAndR = _event => _event.ctrlKey && _event.key === "k";
-    if (pressedControlAndR(event)) {
+    const pressedMetaAndK = _event => _event.metaKey && _event.key === "k";
+    if (pressedMetaAndK(event)) {
       this.props.removeExportOfSelection(this.props.block.id);
       event.preventDefault();
     }

--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -181,7 +181,7 @@ export class BlockEditorEditingPresentational extends React.Component<
       event.preventDefault();
     }
 
-    const pressedControlAndR = _event => _event.metaKey && _event.key === "r";
+    const pressedControlAndR = _event => _event.ctrlKey && _event.key === "k";
     if (pressedControlAndR(event)) {
       this.props.removeExportOfSelection(this.props.block.id);
       event.preventDefault();

--- a/client/src/components/BlockEditor/types.tsx
+++ b/client/src/components/BlockEditor/types.tsx
@@ -20,7 +20,7 @@ export interface Change {
   moveToRangeOf(node: any): Change;
   removeNodeByKey(key: string): Change;
   removeTextByKey(key: string, offset: number, length: number): Change;
-  unwrapInlineByKey(key: string, properties: any): Change;
+  unwrapInlineByKey(key: string, properties?: any): Change;
 }
 
 export interface TextNode {

--- a/client/src/components/BlockHoverMenu/Menu.tsx
+++ b/client/src/components/BlockHoverMenu/Menu.tsx
@@ -28,7 +28,7 @@ const HoverButton = ({ children, onClick }) => (
 );
 
 const ExportedPointerMenu = ({ removeExportOfSelection }) => (
-  <HoverButton onClick={removeExportOfSelection}>Remove Pointer</HoverButton>
+  <HoverButton onClick={() => removeExportOfSelection()}>Remove Pointer</HoverButton>
 );
 
 export class MenuPresentational extends React.Component<any> {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { App } from "./App";
 import "./index.css";

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,4 +1,4 @@
- import * as React from "react";
+import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { App } from "./App";
 import "./index.css";

--- a/client/src/modules/blockEditor/actions.ts
+++ b/client/src/modules/blockEditor/actions.ts
@@ -81,16 +81,22 @@ export const exportSelection = blockId => {
   };
 };
 
-export const removeExportOfSelection = () => {
+export const removeExportOfSelection = blockId => {
   return async (dispatch, getState) => {
     const { blocks, blockEditor } = await getState();
     const { hoveredItem } = blockEditor;
 
-    const block = blocks.blocks.find(b => b.id === hoveredItem.blockId);
+    const block =
+      blocks.blocks.find(b => b.id === blockId || b.id === hoveredItem.blockId);
 
     if (block) {
       const change = block.value.change();
-      slateChangeMutations.removePointerExport(change, hoveredItem);
+      slateChangeMutations.removePointerExport({
+        change,
+        hoveredItem,
+        isHoverRemoval: !blockId,
+      });
+
       slateChangeMutations.normalizeAfterRemoval(change);
 
       dispatch({

--- a/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
+++ b/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
@@ -18,7 +18,7 @@ export function removePointerExport({
   });
 
   if (!idOfPointerToRemove) {
-    console.error("Text cursor is not currently in an export");
+    console.error("Could not determine id of pointer to remove");
     return;
   }
 
@@ -75,6 +75,7 @@ function useFragmentToFindIdOfPointerToRemove(fragment: any) {
 
   const containingExport = containingPointerExportAncestor(curNode, fragment);
   if (!containingExport) {
+    console.error("Text cursor is not currently in an export");
     return undefined;
   }
 

--- a/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
+++ b/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
@@ -1,13 +1,12 @@
 import { containingPointerExportAncestor } from "../slate-utils/containingPointerExportAncestor";
 import { isNestedInExport } from "../slate-utils/isNestedInExport";
 import { getInlinesAsArray } from "../slate-utils/getInlinesAsArray";
-import { Change } from "../../components/BlockEditor/types";
 
 export function removePointerExport({
   change,
   hoveredItem,
   isHoverRemoval,
-}) {
+}: any) {
 
   const { value } = change;
   const { document, fragment } = value;
@@ -40,7 +39,7 @@ function getIdOfPointerToRemove({
   fragment,
   isHoverRemoval,
   hoveredItemId,
-}) {
+}: any) {
   let idOfPointerToRemove;
   if (!isHoverRemoval) {
     idOfPointerToRemove = useFragmentToFindIdOfPointerToRemove(fragment);
@@ -51,7 +50,7 @@ function getIdOfPointerToRemove({
   return idOfPointerToRemove;
 }
 
-function findNodeToRemovebyPointerId(pointerIdOfNodeToRemove, document) {
+function findNodeToRemovebyPointerId(pointerIdOfNodeToRemove: string, document: any) {
   const inlines = getInlinesAsArray(document);
 
   const matchingNodes = inlines.filter(
@@ -68,7 +67,7 @@ function findNodeToRemovebyPointerId(pointerIdOfNodeToRemove, document) {
   return nodeToRemove;
 }
 
-function useFragmentToFindIdOfPointerToRemove(fragment) {
+function useFragmentToFindIdOfPointerToRemove(fragment: any) {
   let curNode = fragment.nodes.get(0);
   while (curNode.nodes) {
     curNode = curNode.nodes.get(0);

--- a/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
+++ b/client/src/slate-helpers/slate-change-mutations/removePointerExport.ts
@@ -1,12 +1,63 @@
+import { containingPointerExportAncestor } from "../slate-utils/containingPointerExportAncestor";
+import { isNestedInExport } from "../slate-utils/isNestedInExport";
 import { getInlinesAsArray } from "../slate-utils/getInlinesAsArray";
 import { Change } from "../../components/BlockEditor/types";
 
-export function removePointerExport(change: Change, hoveredItem: any) {
-  const value = change.value;
-  const inlines = getInlinesAsArray(value.document);
+export function removePointerExport({
+  change,
+  hoveredItem,
+  isHoverRemoval,
+}) {
+
+  const { value } = change;
+  const { document, fragment } = value;
+
+  const idOfPointerToRemove = getIdOfPointerToRemove({
+    fragment,
+    isHoverRemoval,
+    hoveredItemId: hoveredItem.id,
+  });
+
+  if (!idOfPointerToRemove) {
+    console.error("Text cursor is not currently in an export");
+    return;
+  }
+
+  const nodeToRemove = findNodeToRemovebyPointerId(idOfPointerToRemove, document);
+
+  const isNested = isNestedInExport(nodeToRemove, document);
+
+  if (isNested) {
+    change
+      .unwrapInlineByKey(nodeToRemove.key,  { data: { pointerId: idOfPointerToRemove } })
+      .removeNodeByKey(nodeToRemove.key);
+  } else {
+    change.unwrapInlineByKey(nodeToRemove.key,  { data: { pointerId: idOfPointerToRemove } });
+  }
+}
+
+function getIdOfPointerToRemove({
+  fragment,
+  isHoverRemoval,
+  hoveredItemId,
+}) {
+  let idOfPointerToRemove;
+  if (!isHoverRemoval) {
+    idOfPointerToRemove = useFragmentToFindIdOfPointerToRemove(fragment);
+  } else {
+    idOfPointerToRemove = hoveredItemId;
+  }
+
+  return idOfPointerToRemove;
+}
+
+function findNodeToRemovebyPointerId(pointerIdOfNodeToRemove, document) {
+  const inlines = getInlinesAsArray(document);
+
   const matchingNodes = inlines.filter(
-    i => i.toJSON().data.pointerId === hoveredItem.id
+    i => i.data.get("pointerId") === pointerIdOfNodeToRemove
   );
+
   if (!matchingNodes.length) {
     console.error("Exporting node not found in Redux store");
     return;
@@ -14,15 +65,20 @@ export function removePointerExport(change: Change, hoveredItem: any) {
 
   const nodeToRemove = matchingNodes[0];
 
-  // remove pointerExport inline
-  const ancestorNodes = value.document.getAncestors(nodeToRemove.key);
-  const isNested = ancestorNodes.find(ancestor => ancestor.type === "pointerExport");
+  return nodeToRemove;
+}
 
-  if (isNested) {
-    change
-      .unwrapInlineByKey(nodeToRemove.key,  { data: { pointerId: hoveredItem.id } })
-      .removeNodeByKey(nodeToRemove.key);
-  } else {
-    change.unwrapInlineByKey(nodeToRemove.key,  { data: { pointerId: hoveredItem.id } });
+function useFragmentToFindIdOfPointerToRemove(fragment) {
+  let curNode = fragment.nodes.get(0);
+  while (curNode.nodes) {
+    curNode = curNode.nodes.get(0);
   }
+
+  const containingExport = containingPointerExportAncestor(curNode, fragment);
+  if (!containingExport) {
+    return undefined;
+  }
+
+  const idOfPointerToRemove = containingExport.data.get("pointerId");
+  return idOfPointerToRemove;
 }

--- a/client/src/slate-helpers/slate-utils/isNestedInExport.ts
+++ b/client/src/slate-helpers/slate-utils/isNestedInExport.ts
@@ -1,0 +1,5 @@
+export function isNestedInExport(node: any, document: any) {
+  const ancestorNodes = document.getAncestors(node.key);
+  const isNested = ancestorNodes.find(ancestor => ancestor.type === "pointerExport");
+  return isNested;
+}


### PR DESCRIPTION
Make sure your text cursor is in the pointer you'd like to remove. Then press Cmd-R to remove the pointer. (On a PC this might be Ctrl-R? I'll look into this later.)

We can change the keyboard shortcut to whatever we think is best. We can also merge this into the preview branch for experiments.