### PR TITLE
Fixes #47

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as LogRocket from "logrocket";
-import { BrowserRouter, Route, Redirect, withRouter } from "react-router-dom";
+import { BrowserRouter, Route, Redirect } from "react-router-dom";
 import ApolloClient from "apollo-client";
 import { ApolloProvider } from "react-apollo";
 import { HttpLink } from "apollo-link-http";
@@ -18,9 +18,9 @@ import { BetweenEpisodesPage } from "./pages/BetweenEpisodesPage";
 import { RootWorkspacePage } from "./pages/RootWorkspacePage";
 import { applyMiddleware, combineReducers, createStore } from "redux";
 import { blockReducer } from "./modules/blocks/reducer";
-import { closeAllPointerReferences } from "./modules/blockEditor/actions";
 import { blockEditorReducer } from "./modules/blockEditor/reducer";
 import { WorkspaceSubtreePage } from "./pages/WorkspaceSubtreePage";
+import { ClosePointerListener } from "./components/ClosePointerListener";
 import { Header } from "./components/Header";
 
 import { Config } from "./config";
@@ -86,33 +86,6 @@ export class Layout extends React.Component {
   }
 }
 
-function onRouteChange(route: string) {
-  // Close all pointers on route change, so that shared pointers do not remain open.
-  store.dispatch(closeAllPointerReferences());
-}
-
-// Component used to instantiate a unique listener on the history object.
-class HistoryListener extends React.Component<any, any> {
-  public constructor(props: any) {
-    super(props);
-    this.state = {
-      unlisten: this.props.history.listen(onRouteChange)
-    };
-  }
-
-  public componentWillUnmount() {
-    this.state.unlisten();
-  }
-
-  public render() {
-    return (
-      <div />
-    );
-  }
-}
-
-const HistoryListenerWithRouter = withRouter(HistoryListener);
-
 const Routes = () => (
   <div>
     <Route exact={true} path="/workspaces" render={() => <Redirect to="/" />} />
@@ -141,7 +114,7 @@ const Routes = () => (
         return <Redirect to="/" />;
       }}
     />
-    <HistoryListenerWithRouter />
+    <ClosePointerListener />
   </div>
 );
 

--- a/client/src/components/ClosePointerListener.tsx
+++ b/client/src/components/ClosePointerListener.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { closeAllPointerReferences } from "../modules/blockEditor/actions";
+
+class ClosePointerListenerBase extends React.Component<any, any> {
+  public constructor(props: any) {
+    super(props);
+  }
+
+  public componentDidUpdate(prevProps) {
+    // Close all pointers on route change, so that shared pointers do not remain open.
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      this.props.closeAllPointerReferences();
+    }
+  }
+
+  public render() {
+    return null;
+  }
+}
+
+export const ClosePointerListener: any = withRouter(connect(null, { closeAllPointerReferences })(ClosePointerListenerBase));

--- a/client/src/modules/blockEditor/actions.ts
+++ b/client/src/modules/blockEditor/actions.ts
@@ -57,13 +57,10 @@ export const changePointerReference = ({ id, reference }) => {
   };
 };
 
-export const closeAllPointerReferences = () => {
-  return (dispatch, getState) => {
-    dispatch({
-      type: CLOSE_ALL_POINTER_REFERENCES
-    });
-  };
-};
+export const closeAllPointerReferences = () => ({
+  type: CLOSE_ALL_POINTER_REFERENCES
+});
+
 
 export const exportSelection = blockId => {
   return async (dispatch, getState) => {

--- a/client/src/modules/blockEditor/actions.ts
+++ b/client/src/modules/blockEditor/actions.ts
@@ -3,6 +3,7 @@ import * as slateChangeMutations from "../../slate-helpers/slate-change-mutation
 
 export const CHANGE_HOVERED_ITEM = "CHANGE_HOVERED_ITEM";
 export const CHANGE_POINTER_REFERENCE = "CHANGE_POINTER_REFERENCE";
+export const CLOSE_ALL_POINTER_REFERENCES = "CLOSE_ALL_POINTER_REFERENCES";
 
 export const HOVER_ITEM_TYPES = {
   NONE: "NONE",
@@ -52,6 +53,14 @@ export const changePointerReference = ({ id, reference }) => {
       type: CHANGE_POINTER_REFERENCE,
       id,
       reference
+    });
+  };
+};
+
+export const closeAllPointerReferences = () => {
+  return (dispatch, getState) => {
+    dispatch({
+      type: CLOSE_ALL_POINTER_REFERENCES
     });
   };
 };

--- a/client/src/modules/blockEditor/reducer.ts
+++ b/client/src/modules/blockEditor/reducer.ts
@@ -1,4 +1,5 @@
-import { CHANGE_HOVERED_ITEM, CHANGE_POINTER_REFERENCE } from "./actions";
+import { mapValues } from "lodash";
+import { CHANGE_HOVERED_ITEM, CHANGE_POINTER_REFERENCE, CLOSE_ALL_POINTER_REFERENCES } from "./actions";
 
 const initialState = {
   hoveredItem: {
@@ -26,6 +27,11 @@ export const blockEditorReducer = (state = initialState, action) => {
           ...state.pointerReferences,
           ...{ [action.id]: action.reference }
         }
+      };
+    case CLOSE_ALL_POINTER_REFERENCES:
+      return {
+        ...state,
+        pointerReferences: mapValues(state.pointerReferences, (ref: object) => { return {...ref, isOpen: false }; })
       };
     default:
       return state;


### PR DESCRIPTION
Added a history listener, which closes all pointers during page navigation.

As far as I can tell, it's hard to detect navigation on individual workspace components; hence we just do it globally.  The longer term/future solution is to include the workspace ID as part of the stored pointer state and thread this through to the pointer components, so that expansion can be preserved per workspace.