### PR TITLE
 Cleans up display of front page.

### DIFF
--- a/client/src/lib/slateParser.ts
+++ b/client/src/lib/slateParser.ts
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import Plain from "slate-plain-serializer";
 
 export function valueToDatabaseJSON(value: any) {
@@ -17,4 +18,30 @@ export function databaseJSONToValue(databaseJson: any) {
   } else {
     return Plain.deserialize("");
   }
+}
+
+export function listOfSlateNodesToText(list: Array<any>) {
+  return _.map(_.map(list, slateNodeToText), _.trim).join(" ");
+}
+
+export function slateNodeToText(node: any) {
+  let prefix = "";
+  let mid = "";
+  let suffix = "";
+  if (node.type === "pointerExport") {
+    prefix = "[";
+    suffix = "]";
+  } else {
+    prefix = "";
+    suffix = "";
+  }
+
+  if (_.has(node, "nodes")) {
+    mid = listOfSlateNodesToText(node.nodes);
+  } else if (_.has(node, "leaves")) {
+    mid = listOfSlateNodesToText(node.leaves);
+  } else if (_.has(node, "text")) {
+    mid = node.text;
+  }
+  return prefix + mid + suffix;
 }

--- a/client/src/pages/RootWorkspacePage/RootBlock.tsx
+++ b/client/src/pages/RootWorkspacePage/RootBlock.tsx
@@ -23,8 +23,7 @@ const RootBlock = ({ availablePointers = [], block, defaultText = ""}) => {
         }}
       >{displayText}</div>
     );
-  }
-  else {
+  } else {
     return null;
   }
 };

--- a/client/src/pages/RootWorkspacePage/RootBlock.tsx
+++ b/client/src/pages/RootWorkspacePage/RootBlock.tsx
@@ -1,22 +1,30 @@
+import * as _ from "lodash";
 import * as React from "react";
-import { BlockEditor } from "../../components/BlockEditor";
-import { databaseJSONToValue } from "../../lib/slateParser";
+import { listOfSlateNodesToText } from "../../lib/slateParser";
 
-const RootBlock = ({ availablePointers = [], block }) => {
+const RootBlock = ({ availablePointers = [], block, defaultText = ""}) => {
+  let displayText = defaultText;
   if (block && block.value) {
+    let blockText = listOfSlateNodesToText(block.value);
+    if (_.trim(blockText) !== "") {
+      displayText = blockText;
+    }
+  }
+  if (displayText !== "") {
     return (
-      <div style={{ display: "inline-block" }}>
-        <BlockEditor
-          availablePointers={availablePointers}
-          blockId={block.id}
-          initialValue={databaseJSONToValue(block.value)}
-          name={block.id}
-          readOnly={true}
-          shouldAutosave={false}
-        />
-      </div>
+      <div
+        style={{
+          display: "inline-block",
+          maxWidth: "100%",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          minWidth: 0
+        }}
+      >{displayText}</div>
     );
-  } else {
+  }
+  else {
     return null;
   }
 };

--- a/client/src/pages/RootWorkspacePage/RootWorkspace.tsx
+++ b/client/src/pages/RootWorkspacePage/RootWorkspace.tsx
@@ -24,6 +24,8 @@ const WorkspaceContainer = styled.div`
   ${blockBorderAndBoxShadow};
   background-color: ${homepageWorkspaceBgColor};
   padding: 10px;
+  display: flex;
+  justify-content: space-between;
 `;
 
 const ScratchpadContainer = styled.div`
@@ -60,94 +62,93 @@ class RootWorkspacePresentational extends React.Component<any, any> {
 
     return (
       <WorkspaceContainer style={this.props.style}>
-        {
-          Auth.isAdmin()
-          &&
-          <div
-            style={{
-              marginBottom: "5px",
-            }}
-          >
-            <Checkbox
-              style={{
-                backgroundColor: adminCheckboxBgColor,
-                border: `1px solid ${adminCheckboxBorderColor}`,
-                borderRadius: "3px",
-                padding: "5px 5px 5px 25px",
-                opacity: this.state.isPublicCheckboxStatusPending ? 0.75 : 1,
-              }}
-              inline={true}
-              type="checkbox"
-              checked={workspace.isPublic}
-              onChange={this.handleOnIsPublicCheckboxChange}
-            >
-              {
-                this.state.isPublicCheckboxStatusPending
-                ?
-                "updating..."
-                :
-                "appears on front page"
-              }
-            </Checkbox>
-            <Checkbox
-              style={{
-                backgroundColor: adminCheckboxBgColor,
-                border: `1px solid ${adminCheckboxBorderColor}`,
-                borderRadius: "3px",
-                padding: "5px 5px 5px 25px",
-                opacity: this.state.isEligibleCheckboxStatusPending ? 0.75 : 1,
-              }}
-              inline={true}
-              type="checkbox"
-              checked={workspace.isEligibleForAssignment}
-              onChange={this.handleOnIsEligibleCheckboxChange}
-            >
-              {
-                this.state.isEligibleCheckboxStatusPending
-                ?
-                "updating..."
-                :
-                "is eligible for assignment"
-              }
-            </Checkbox>
-          </div>
-        }
-        <Link to={`/workspaces/${workspace.id}`}>
+        <div style={{flex: "1 0 0px", minWidth: 0}}>
+          <Link to={`/workspaces/${workspace.id}`}>
+            <RootBlock
+              availablePointers={workspace.connectedPointers}
+              block={question}
+            />
+          </Link>
+          <br />
+          <ScratchpadContainer>
+            <RootBlock
+              availablePointers={workspace.connectedPointers}
+              block={scratchpad}
+              defaultText="(no description)"
+            />
+          </ScratchpadContainer>
           <RootBlock
             availablePointers={workspace.connectedPointers}
-            block={question}
+            block={answer}
           />
-        </Link>
-
-        {" "}
-
-        <RootBlock
-          availablePointers={workspace.connectedPointers}
-          block={answer}
-        />
-
-        <Link to={`/workspaces/${workspace.id}/subtree`}>
-          <Button
-            bsSize="xsmall"
-            bsStyle="default"
-            className="pull-right"
-            style={{
-              margin: "5px 1px",
-              padding: "1px 4px",
-            }}
-          >
-            Tree »
-          </Button>
-        </Link>
-
-        <ScratchpadContainer>
-          <RootBlock
-            availablePointers={workspace.connectedPointers}
-            block={scratchpad}
-          />
-        </ScratchpadContainer>
-
-        <div style={{ clear: "both" }} />
+        </div>
+        <div style={{flexShrink: 0, flexGrow: 0, display: "flex", flexDirection: "column", justifyContent: "space-between"}}>
+          {
+            Auth.isAdmin()
+            &&
+            <div
+              style={{
+                marginBottom: "5px",
+              }}
+            >
+              <Checkbox
+                style={{
+                  backgroundColor: adminCheckboxBgColor,
+                  border: `1px solid ${adminCheckboxBorderColor}`,
+                  borderRadius: "3px",
+                  padding: "5px 5px 5px 25px",
+                  opacity: this.state.isPublicCheckboxStatusPending ? 0.75 : 1,
+                }}
+                inline={true}
+                type="checkbox"
+                checked={workspace.isPublic}
+                onChange={this.handleOnIsPublicCheckboxChange}
+              >
+                {
+                  this.state.isPublicCheckboxStatusPending
+                  ?
+                  "updating..."
+                  :
+                  "appears on front page"
+                }
+              </Checkbox>
+              <Checkbox
+                style={{
+                  backgroundColor: adminCheckboxBgColor,
+                  border: `1px solid ${adminCheckboxBorderColor}`,
+                  borderRadius: "3px",
+                  padding: "5px 5px 5px 25px",
+                  opacity: this.state.isEligibleCheckboxStatusPending ? 0.75 : 1,
+                }}
+                inline={true}
+                type="checkbox"
+                checked={workspace.isEligibleForAssignment}
+                onChange={this.handleOnIsEligibleCheckboxChange}
+              >
+                {
+                  this.state.isEligibleCheckboxStatusPending
+                  ?
+                  "updating..."
+                  :
+                  "is eligible for assignment"
+                }
+              </Checkbox>
+            </div>
+          }
+          <Link to={`/workspaces/${workspace.id}/subtree`}>
+            <Button
+              bsSize="xsmall"
+              bsStyle="default"
+              className="pull-right"
+              style={{
+                margin: "5px 1px",
+                padding: "1px 4px",
+              }}
+            >
+              Tree »
+            </Button>
+          </Link>
+        </div>
       </WorkspaceContainer>
     );
   }


### PR DESCRIPTION
Several changes to make the front page display cleaner and more uniform:
* Uses a text display of the main blocks instead of an instance of the slate editor; this allows us to display the blocks (question, answer, and scratchpad/description) on one line each using ellipsis overflow.  It also eliminates noise from green inline pointers.
* Uses flexbox to display editing buttons on the right-hand side above the Tree view button, lowering the vertical display height for admins.

This does have the negative effect of simply showing less info on the front page, since blocks are flattened.  This messes with paragraph structure, pointers (displayed using square brackets), and any other inline elements that might be included in the future.

Currently height of each card is not completely fixed, since the answer display line at the bottom is optional.  This seemed like the best trade-off.