### PR TITLE
Enable wrapping of long links and unbroken text in subtree view page.

### DIFF
--- a/client/src/components/WorkspaceCard/BlockSection.tsx
+++ b/client/src/components/WorkspaceCard/BlockSection.tsx
@@ -35,10 +35,12 @@ const BlockContainer = styled.div`
   flex: 1;
 `;
 
+// Setting min-width enables wrapping behavior.
 const BlockEditorContainer = styled.div`
-  margin: 4px 0 4px 0;
+  margin: 4px 9px 4px 0;
   float: left;
   flex: 40;
+  min-width: 1px;
 `;
 
 const BlockSectionContainer = styled.div`


### PR DESCRIPTION
Solves #231.