### PR TITLE
Fixes #257 by refactoring import autocomplete/conversion code.

### DIFF
--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -239,15 +239,10 @@ export class BlockEditorEditingPresentational extends React.Component<
       locations = _.filter(locations, loc => !this.isActiveImportPatternLocation(loc));
     }
 
-    let anyConverted = false;
-    locations.forEach(location => {
-      if (this.convertImportPatternLocation(location)) {
-        anyConverted = true;
-      }
-    });
+    const converted = (locations.length !== 0) && this.convertImportPatternLocation(locations[0]);
 
-    // Both Enter and Left Arrow appear to have default behavior inside Slate interfering with the conversion.
-    if ((event.key === "Enter" || event.key === "ArrowLeft") && anyConverted) {
+    // Both Enter and arrows appear to have default behavior inside Slate interfering with the conversion.
+    if (converted && (event.key === "Enter" || event.key === "ArrowLeft" || event.key === "ArrowRight")) {
       return true;
     }
 
@@ -258,7 +253,9 @@ export class BlockEditorEditingPresentational extends React.Component<
   private checkGlobalImportConversion() {
     const textNodesArray = this.props.value.document.getTexts().toArray();
     const locations: ImportPatternLocation[] = this.getImportPatternLocationsInArrayOfTextNodes(textNodesArray);
-    locations.forEach(location => this.convertImportPatternLocation(location));
+    if ((locations.length !== 0) && this.convertImportPatternLocation(locations[0])) {
+      this.checkGlobalImportConversion();
+    }
   }
 
   private onKeyDown = (event: any, change: Change) => {

--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -109,6 +109,7 @@ export class BlockEditorEditingPresentational extends React.Component<
       value: change.value,
       pointerChanged: false
     });
+    this.applyGlobalInputConversion();
   }
 
   public render() {

--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -239,10 +239,16 @@ export class BlockEditorEditingPresentational extends React.Component<
       locations = _.filter(locations, loc => !this.isActiveImportPatternLocation(loc));
     }
 
-    const converted = (locations.length !== 0) && this.convertImportPatternLocation(locations[0]);
+    let anyConverted = false;
+    for (let ii = 0; ii < locations.length; ii++) {
+      if (this.convertImportPatternLocation(locations[ii])) {
+        anyConverted = true;
+        break;
+      }
+    }
 
     // Both Enter and arrows appear to have default behavior inside Slate interfering with the conversion.
-    if (converted && (event.key === "Enter" || event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+    if (anyConverted && (event.key === "Enter" || event.key === "ArrowLeft" || event.key === "ArrowRight")) {
       return true;
     }
 
@@ -253,8 +259,11 @@ export class BlockEditorEditingPresentational extends React.Component<
   private checkGlobalImportConversion() {
     const textNodesArray = this.props.value.document.getTexts().toArray();
     const locations: ImportPatternLocation[] = this.getImportPatternLocationsInArrayOfTextNodes(textNodesArray);
-    if ((locations.length !== 0) && this.convertImportPatternLocation(locations[0])) {
-      this.checkGlobalImportConversion();
+    for (let ii = 0; ii < locations.length; ii++) {
+      if (this.convertImportPatternLocation(locations[ii])) {
+        this.checkGlobalImportConversion();
+        break;
+      }
     }
   }
 

--- a/client/src/components/BlockEditor/BlockEditorEditing.tsx
+++ b/client/src/components/BlockEditor/BlockEditorEditing.tsx
@@ -1,6 +1,4 @@
 import * as React from "react";
-import { Inline } from "slate";
-import * as uuidv1 from "uuid/v1";
 import { Editor } from "slate-react";
 import { compose, withProps, withState } from "recompose";
 import { graphql } from "react-apollo";
@@ -8,6 +6,7 @@ import { connect } from "react-redux";
 import { updateBlock } from "../../modules/blocks/actions";
 import { MenuBar } from "./MenuBar";
 import { MutationStatus } from "./types";
+import { applyKeydownImportConversionInSlateValue, applyGlobalImportConversionInSlateValue } from "./importConversion";
 import { valueToDatabaseJSON } from "../../lib/slateParser";
 import { exportSelection, removeExportOfSelection } from "../../modules/blockEditor/actions";
 import * as _ from "lodash";
@@ -16,19 +15,6 @@ import { Change } from "./types";
 import * as slateChangeMutations from "../../slate-helpers/slate-change-mutations";
 
 const AUTOSAVE_EVERY_N_SECONDS = 3;
-const NUMBER_REGEX = /[0-9]/;
-
-function inlinePointerImportJSON(pointerId: string) {
-  return Inline.fromJSON({
-    object: "inline",
-    type: "pointerImport",
-    isVoid: true,
-    data: {
-      pointerId: pointerId,
-      internalReferenceId: uuidv1()
-    }
-  });
-}
 
 // Eventually we'll type out many of these items more spefically, but that's a future refactor.
 interface BlockEditorEditingPresentationalProps {
@@ -56,13 +42,6 @@ interface BlockEditorEditingPresentationalState {
   hasChangedSinceDatabaseSave: boolean;
 }
 
-interface ImportPatternLocation {
-  startKey: string;
-  startOffset: number;
-  pointerNum: number;
-  length: number;
-}
-
 export class BlockEditorEditingPresentational extends React.Component<
   BlockEditorEditingPresentationalProps,
   BlockEditorEditingPresentationalState
@@ -71,7 +50,7 @@ export class BlockEditorEditingPresentational extends React.Component<
   private autosaveInterval: any;
 
   private handleBlur = _.debounce(() => {
-    this.checkGlobalImportConversion();
+    this.applyGlobalInputConversion();
     if (this.props.shouldAutosave) {
       this.considerSaveToDatabase();
       this.endAutosaveInterval();
@@ -156,117 +135,6 @@ export class BlockEditorEditingPresentational extends React.Component<
     );
   }
 
-  private getImportPatternLocationsInTextNode(node: any): ImportPatternLocation[] {
-    const locations: ImportPatternLocation[] = [];
-    let inMatch = false;
-    let matchStart = -1;
-    let matchChars = "";
-    const text = node.text;
-    for (let ii = 0; ii < text.length; ii++) {
-      if (inMatch) {
-        const charIsNumber = !!text[ii].match(NUMBER_REGEX);
-
-        if (charIsNumber) {
-          matchChars = matchChars.concat(text[ii]);
-        }
-        if ((!charIsNumber || ii === text.length - 1) && (matchChars.length > 0))  {
-          locations.push({
-            startKey: node.key,
-            startOffset: matchStart,
-            pointerNum: Number(matchChars),
-            length: matchChars.length + 1
-          });
-          inMatch = false;
-        }
-      }
-      if (text[ii] === "$") {
-        inMatch = true;
-        matchStart = ii;
-        matchChars = "";
-      }
-    }
-
-    return locations;
-  }
-
-  private getImportPatternLocationsInArrayOfTextNodes(textNodes: any[]): ImportPatternLocation[] {
-    // We only find import patterns contained within a single text node.
-    const locationsPerNode = _.map(textNodes, node => this.getImportPatternLocationsInTextNode(node));
-    return _.flatten(locationsPerNode);
-  }
-
-  // Checks whether current input focus is at the very end of the import pattern location.
-  private isActiveImportPatternLocation(location: ImportPatternLocation) {
-    return (
-      this.props.value.focusKey === location.startKey &&
-      this.props.value.focusOffset === (location.startOffset + location.length)
-    );
-  }
-
-  // Attempts to convert text at the given location (e.g. "$3") to a corresponding inline import node.
-  private convertImportPatternLocation(location: ImportPatternLocation) {
-    const pointer = this.props.availablePointers[location.pointerNum - 1];
-
-    if (!!pointer) {
-      const { value } = this.props.value
-        .change()
-        .select({
-          anchorKey: location.startKey,
-          anchorOffset: location.startOffset,
-          focusKey: location.startKey,
-          focusOffset: location.startOffset,
-        })
-        .deleteForward(location.length)
-        .insertInline(inlinePointerImportJSON(pointer.data.pointerId))
-        .collapseToStartOfNextText()
-        .focus();
-
-      this.onChange(value, true);
-      return true;
-    }
-
-    return false;
-  }
-
-  // Returns true if we should prevent current character from being inserted, false otherwise.
-  private checkKeydownImportConversion(event: any) {
-      // Attempts import conversions in the focused node only.
-    let locations: ImportPatternLocation[] = this.getImportPatternLocationsInArrayOfTextNodes([this.props.value.focusText]);
-    const isNumberKey = !!event.key.match(NUMBER_REGEX);
-
-    if (isNumberKey) {
-      // Do not attempt to complete the focused location (if any), since we could still be adding to it.
-      locations = _.filter(locations, loc => !this.isActiveImportPatternLocation(loc));
-    }
-
-    let anyConverted = false;
-    for (let ii = 0; ii < locations.length; ii++) {
-      if (this.convertImportPatternLocation(locations[ii])) {
-        anyConverted = true;
-        break;
-      }
-    }
-
-    // Both Enter and arrows appear to have default behavior inside Slate interfering with the conversion.
-    if (anyConverted && (event.key === "Enter" || event.key === "ArrowLeft" || event.key === "ArrowRight")) {
-      return true;
-    }
-
-    return false;
-  }
-
-  // Attempts import conversions on the whole block.
-  private checkGlobalImportConversion() {
-    const textNodesArray = this.props.value.document.getTexts().toArray();
-    const locations: ImportPatternLocation[] = this.getImportPatternLocationsInArrayOfTextNodes(textNodesArray);
-    for (let ii = 0; ii < locations.length; ii++) {
-      if (this.convertImportPatternLocation(locations[ii])) {
-        this.checkGlobalImportConversion();
-        break;
-      }
-    }
-  }
-
   private onKeyDown = (event: any, change: Change) => {
     const pressedMetaAndE = _event => _event.metaKey && _event.key === "e";
     if (pressedMetaAndE(event)) {
@@ -284,13 +152,23 @@ export class BlockEditorEditingPresentational extends React.Component<
       this.props.onKeyDown(event);
     }
 
-    const shouldPreventDefault = this.checkKeydownImportConversion(event);
+    const { shouldPreventDefault, updatedValue } = applyKeydownImportConversionInSlateValue(event, this.props.value, this.props.availablePointers);
+    if (updatedValue) {
+      this.onChange(updatedValue, true);
+    }
     if (shouldPreventDefault) {
       return false;
     }
 
     return undefined;
   };
+
+  private applyGlobalInputConversion = () => {
+    const updatedValue = applyGlobalImportConversionInSlateValue(this.props.value, this.props.availablePointers);
+    if (updatedValue) {
+      this.onChange(updatedValue, true);
+    }
+  }
 
   private handleSquareBracketExport = () => {
     // check to see whether there are a balanced number of square brackets
@@ -317,7 +195,7 @@ export class BlockEditorEditingPresentational extends React.Component<
   private onPaste = (event: any) => {
     // We do this in a timeout to avoid interactions with the linkify plugin.
     // Ideally we could just put this at the appropriate point in the plugin stack and pass the change value through.
-    setTimeout(() => this.checkGlobalImportConversion(), 0);
+    setTimeout(() => this.applyGlobalInputConversion(), 0);
     return undefined;
   }
 

--- a/client/src/components/BlockEditor/importConversion.tsx
+++ b/client/src/components/BlockEditor/importConversion.tsx
@@ -1,0 +1,144 @@
+import { Inline } from "slate";
+import * as uuidv1 from "uuid/v1";
+import * as _ from "lodash";
+
+const NUMBER_REGEX = /[0-9]/;
+
+export interface ImportPatternLocation {
+  startKey: string;
+  startOffset: number;
+  pointerNum: number;
+  length: number;
+}
+
+function inlinePointerImportJSON(pointerId: string) {
+  return Inline.fromJSON({
+    object: "inline",
+    type: "pointerImport",
+    isVoid: true,
+    data: {
+      pointerId: pointerId,
+      internalReferenceId: uuidv1()
+    }
+  });
+}
+
+function getImportPatternLocationsInTextNode(node: any): ImportPatternLocation[] {
+  const locations: ImportPatternLocation[] = [];
+  let inMatch = false;
+  let matchStart = -1;
+  let matchChars = "";
+  const text = node.text;
+  for (let ii = 0; ii < text.length; ii++) {
+    if (inMatch) {
+      const charIsNumber = !!text[ii].match(NUMBER_REGEX);
+
+      if (charIsNumber) {
+        matchChars = matchChars.concat(text[ii]);
+      }
+      if ((!charIsNumber || ii === text.length - 1) && (matchChars.length > 0))  {
+        locations.push({
+          startKey: node.key,
+          startOffset: matchStart,
+          pointerNum: Number(matchChars),
+          length: matchChars.length + 1
+        });
+        inMatch = false;
+      }
+    }
+    if (text[ii] === "$") {
+      inMatch = true;
+      matchStart = ii;
+      matchChars = "";
+    }
+  }
+
+  return locations;
+}
+
+function getImportPatternLocationsInArrayOfTextNodes(textNodes: any[]): ImportPatternLocation[] {
+  // We only find import patterns contained within a single text node.
+  const locationsPerNode = _.map(textNodes, node => getImportPatternLocationsInTextNode(node));
+  return _.flatten(locationsPerNode);
+}
+
+// Checks whether current input focus is at the very end of the import pattern location.
+function isActiveImportPatternLocation(location: ImportPatternLocation, value: any) {
+  return (
+    value.focusKey === location.startKey &&
+    value.focusOffset === (location.startOffset + location.length)
+  );
+}
+
+  // Attempts to convert text at the given location (e.g. "$3") to a corresponding inline import node.
+function convertImportPatternLocationInSlateValue(location: ImportPatternLocation, initialValue: any, availablePointers: any[]) {
+  const pointer = availablePointers[location.pointerNum - 1];
+
+  if (!!pointer) {
+    const { value } = initialValue.change()
+      .select({
+        anchorKey: location.startKey,
+        anchorOffset: location.startOffset,
+        focusKey: location.startKey,
+        focusOffset: location.startOffset,
+      })
+      .deleteForward(location.length)
+      .insertInline(inlinePointerImportJSON(pointer.data.pointerId))
+      .collapseToStartOfNextText()
+      .focus();
+
+    return value;
+  }
+
+  return undefined;
+}
+
+export function applyKeydownImportConversionInSlateValue(event: any, originalValue: any, availablePointers: any[]) {
+    // Attempts import conversions in the focused node only.
+  let locations: ImportPatternLocation[] = getImportPatternLocationsInArrayOfTextNodes([originalValue.focusText]);
+  const isNumberKey = !!event.key.match(NUMBER_REGEX);
+
+  if (isNumberKey) {
+    // Do not attempt to complete the focused location (if any), since we could still be adding to it.
+    locations = _.filter(locations, loc => !isActiveImportPatternLocation(loc, originalValue));
+  }
+
+  let updatedValue = undefined;
+  for (let ii = 0; ii < locations.length; ii++) {
+    updatedValue = convertImportPatternLocationInSlateValue(locations[ii], originalValue, availablePointers);
+    if (updatedValue) {
+      break;
+    }
+  }
+
+  // Both Enter and arrows appear to have default behavior inside Slate interfering with the conversion.
+  if (updatedValue && (event.key === "Enter" || event.key === "ArrowLeft" || event.key === "ArrowRight")) {
+    return {
+      shouldPreventDefault: true,
+      updatedValue: updatedValue
+    };
+  }
+
+  return {
+    shouldPreventDefault: false,
+    updatedValue: updatedValue
+  };
+}
+
+// Attempts import conversions on the whole block.
+export function applyGlobalImportConversionInSlateValue(originalValue: any, availablePointers: any[]) {
+  const textNodesArray = originalValue.document.getTexts().toArray();
+  const locations: ImportPatternLocation[] = getImportPatternLocationsInArrayOfTextNodes(textNodesArray);
+  for (let ii = 0; ii < locations.length; ii++) {
+    const updatedValue = convertImportPatternLocationInSlateValue(locations[ii], originalValue, availablePointers);
+    if (updatedValue) {
+       const recurseValue = applyGlobalImportConversionInSlateValue(updatedValue, availablePointers);
+       if (recurseValue) {
+         return recurseValue;
+       } else {
+         return updatedValue;
+       }
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
This adds import conversion on paste, as well as conversion on changing focus away from editor.

Some remaining deficiencies:
* When pasting imports, the cursor ends up after the last import converted instead of at the end of the pasted text.
* Clicking elsewhere in the same editor doesn't convert imports.