### PR TITLE
Use scheduler, not query param, for if workspace active

### DIFF
--- a/client/src/components/BlockEditor/index.tsx
+++ b/client/src/components/BlockEditor/index.tsx
@@ -106,6 +106,7 @@ class BlockEditorPresentational extends React.Component<any, any> {
       isInOracleModeAndIsUserOracle: newProps.oracleModeQuery.oracleMode && newProps.isUserOracle,
       isInOracleMode: newProps.oracleModeQuery.oracleMode,
       isUserOracle: newProps.isUserOracle,
+      isActive: newProps.isActive,
     };
     this.setState({
       plugins: [LinkifyPlugin(), CopyPastePlugin({ pastedExportFormat: newProps.pastedExportFormat }), SoftBreak({}), SlatePointers(SlatePointerInputs)]

--- a/client/src/lib/slate-pointers/PointerImportNode.tsx
+++ b/client/src/lib/slate-pointers/PointerImportNode.tsx
@@ -97,7 +97,7 @@ class PointerImportNodePresentational extends React.Component<any, any> {
       return;
     }
 
-    const isAdminNotInFlow = Auth.isAdmin() && !parseQueryString(window.location.search).active;
+    const isAdminNotInFlow = Auth.isAdmin() && !this.props.isActive;
     const isOracleInOracleMode = this.props.isInOracleMode && this.props.isUserOracle;
 
     if (!this.props.hasExportBeenOpened && (isAdminNotInFlow || isOracleInOracleMode)) {
@@ -134,8 +134,7 @@ class PointerImportNodePresentational extends React.Component<any, any> {
   };
 
   public handleClosedPointerClick = (e: Event, pointerId: string, exportPointerId: string) => {
-    const queryParams = parseQueryString(window.location.search);
-    const isActive = queryParams.active;
+    const isActive = this.props.isActive;
 
     if (this.isLocked() && this.state.isLocked) {
       this.setState({ isLocked: false });

--- a/client/src/lib/slate-pointers/index.tsx
+++ b/client/src/lib/slate-pointers/index.tsx
@@ -108,6 +108,7 @@ function SlatePointers(options: any = {}) {
 
         return (
           <PointerImportNode
+            isActive={options.isActive}
             visibleExportIds={options.visibleExportIds}
             exportLockStatusInfo={options.exportLockStatusInfo}
             isInOracleMode={options.isInOracleMode}

--- a/client/src/pages/EpisodeShowPage/ChildrenSidebar.tsx
+++ b/client/src/pages/EpisodeShowPage/ChildrenSidebar.tsx
@@ -93,6 +93,7 @@ export class Child extends React.Component<any, any> {
             {questionRelationship.findBlock().value && (
               <BlockEditor
                 {...questionRelationship.blockEditorAttributes()}
+                isActive={this.props.isActive}
                 isUserOracle={this.props.isUserOracle}
                 readOnly={true}
                 availablePointers={availablePointers}
@@ -140,6 +141,7 @@ export class Child extends React.Component<any, any> {
             <BlockEditorContainer>
               <BlockEditor
                 {...questionRelationship.blockEditorAttributes()}
+                isActive={this.props.isActive}
                 isUserOracle={this.props.isUserOracle}
                 availablePointers={availablePointers}
                 visibleExportIds={this.props.visibleExportIds}
@@ -167,6 +169,7 @@ export class Child extends React.Component<any, any> {
                   ?
                     <BlockEditor
                       {...answerDraftRelationship.blockEditorAttributes()}
+                      isActive={this.props.isActive}
                       isUserOracle={this.props.isUserOracle}
                       availablePointers={availablePointers}
                       visibleExportIds={this.props.visibleExportIds}
@@ -176,6 +179,7 @@ export class Child extends React.Component<any, any> {
                   :
                     <BlockEditor
                       {...answerRelationship.blockEditorAttributes()}
+                      isActive={this.props.isActive}
                       isUserOracle={this.props.isUserOracle}
                       availablePointers={availablePointers}
                       visibleExportIds={this.props.visibleExportIds}
@@ -350,6 +354,7 @@ export class ChildrenSidebar extends React.Component<any, any> {
                     }}
                   >
                     <Child
+                      isActive={this.props.isActive}
                       isUserOracle={this.props.isUserOracle}
                       pastedExportFormat={this.props.pastedExportFormat}
                       shouldAutoExport={this.props.shouldAutoExport}

--- a/client/src/pages/EpisodeShowPage/index.tsx
+++ b/client/src/pages/EpisodeShowPage/index.tsx
@@ -80,6 +80,9 @@ const WORKSPACE_QUERY = gql`
       allocatedBudget
       exportLockStatusInfo
       depth
+      currentlyActiveUser {
+        id
+      }
       childWorkspaces {
         id
         createdAt
@@ -337,7 +340,7 @@ export class WorkspaceView extends React.Component<any, any> {
 
     const queryParams = parseQueryString(window.location.search);
     const isIsolatedWorkspace = queryParams.isolated === "true";
-    const isActive = queryParams.active;
+    const isActive = workspace.currentlyActiveUser && workspace.currentlyActiveUser.id === Auth.userId();
     const experimentId = queryParams.experiment;
     const hasURLTimeRestriction = queryParams.timer;
     const hasTimerEnded = this.state.hasTimerEnded;
@@ -485,6 +488,7 @@ export class WorkspaceView extends React.Component<any, any> {
                           }}
                         >
                           <BlockEditor
+                            isActive={isActive}
                             isUserOracle={isUserOracle}
                             availablePointers={availablePointers}
                             exportLockStatusInfo={exportLockStatusInfo}
@@ -528,6 +532,7 @@ export class WorkspaceView extends React.Component<any, any> {
                         <BlockHeader>Scratchpad</BlockHeader>
                         <BlockBody>
                           <BlockEditor
+                            isActive={isActive}
                             isUserOracle={isUserOracle}
                             availablePointers={availablePointers}
                             visibleExportIds={visibleExportIds}
@@ -546,6 +551,7 @@ export class WorkspaceView extends React.Component<any, any> {
                         <BlockHeader>Response</BlockHeader>
                         <BlockBody>
                           <BlockEditor
+                            isActive={isActive}
                             isUserOracle={isUserOracle}
                             availablePointers={availablePointers}
                             visibleExportIds={visibleExportIds}

--- a/client/src/pages/NextEpisodeShowPage.tsx
+++ b/client/src/pages/NextEpisodeShowPage.tsx
@@ -151,7 +151,7 @@ export class NextEpisodeShowPagePresentational extends React.Component<any, any>
         </ContentContainer>
       );
     } else {
-      const redirectQueryParams = `?isolated=true&active=true&experiment=${queryParams.experiment}`;
+      const redirectQueryParams = `?isolated=true&experiment=${queryParams.experiment}`;
       window.location.href = `${window.location.origin}/workspaces/${this.state.workspaceId}${redirectQueryParams}`;
       return null;
     }

--- a/client/src/pages/NextMaybeSuboptimalEpisodeShowPage.tsx
+++ b/client/src/pages/NextMaybeSuboptimalEpisodeShowPage.tsx
@@ -97,7 +97,7 @@ export class NextMaybeSuboptimalEpisodeShowPagePresentational extends React.Comp
         </ContentContainer>
       );
     } else {
-      const redirectQueryParams = `?isolated=true&active=true&experiment=${queryParams.experiment}`;
+      const redirectQueryParams = `?isolated=true&experiment=${queryParams.experiment}`;
       window.location.href = `${window.location.origin}/workspaces/${this.state.workspaceId}${redirectQueryParams}`;
       return null;
     }


### PR DESCRIPTION
This uses server-side scheduling data, as opposed to a query param, to determine whether a user should see the "active workspace" UI . This also concerns whether "unlocking" an import is permanent: within the "active workspace" UI it is, but otherwise it isn't. Overall, this makes many things more robust, and will also make it easier to share links without sending users to the "active workspace" version of a workspace.