### PR TITLE
Avoid isRequestingLazyUnlock being empty string

### DIFF
--- a/server/lib/models/workspace.ts
+++ b/server/lib/models/workspace.ts
@@ -545,7 +545,7 @@ export default class Workspace extends Model<Workspace> {
     creatorId,
     isPublic,
   }) {
-    const initialText = _.get(question, "[0].nodes[0].leaves[0].text");
+    const initialText = _.get(question, "[0].nodes[0].leaves[0].text", "");
     const isRequestingLazyUnlock = initialText.trim().slice(0, 6).toUpperCase() === "UNLOCK";
 
     let workspaceContainingLazyPointer;

--- a/server/lib/models/workspace.ts
+++ b/server/lib/models/workspace.ts
@@ -545,10 +545,8 @@ export default class Workspace extends Model<Workspace> {
     creatorId,
     isPublic,
   }) {
-    const isRequestingLazyUnlock =
-      _.get(question, "[0].nodes[0].leaves[0].text")
-      &&
-      _.get(question, "[0].nodes[0].leaves[0].text").trim().slice(0, 6).toUpperCase() === "UNLOCK";
+    const initialText = _.get(question, "[0].nodes[0].leaves[0].text");
+    const isRequestingLazyUnlock = initialText.trim().slice(0, 6).toUpperCase() === "UNLOCK";
 
     let workspaceContainingLazyPointer;
     if (isRequestingLazyUnlock) {


### PR DESCRIPTION
If first conjunction was empty string, entire thing short-circuited to it.