### PR TITLE
Parent stale if all subq resolved or archived

### DIFF
--- a/server/lib/schema/index.ts
+++ b/server/lib/schema/index.ts
@@ -922,14 +922,14 @@ const schema = new GraphQLSchema({
                 return false;
               }
               const children = await grandParent.$get("childWorkspaces") as Workspace[];
-              let allResolved = true;
+              let allResolvedOrArchived = true;
               for (const child of children) {
-                if (!child.isCurrentlyResolved) {
-                  allResolved = false;
+                if (!(child.isCurrentlyResolved || child.isArchived)) {
+                  allResolvedOrArchived = false;
                   break;
                 }
               }
-              if (allResolved) {
+              if (allResolvedOrArchived) {
                 await grandParent.update({
                   isStale: true,
                   isNotStaleRelativeToUser: [],
@@ -1008,14 +1008,14 @@ const schema = new GraphQLSchema({
                       return;
                     }
                     const children = await parent.$get("childWorkspaces") as Workspace[];
-                    let allResolved = true;
+                    let allResolvedOrArchived = true;
                     for (const child of children) {
-                      if (!child.isCurrentlyResolved) {
-                        allResolved = false;
+                      if (!(child.isCurrentlyResolved || child.isArchived)) {
+                        allResolvedOrArchived = false;
                         break;
                       }
                     }
-                    if (allResolved) {
+                    if (allResolvedOrArchived) {
                       await parent.update({
                         isStale: true,
                         isNotStaleRelativeToUser: [],
@@ -1051,14 +1051,14 @@ const schema = new GraphQLSchema({
                         const isNotRoot = greatGrandparentWorkspace.parentId;
                         if (isNotRoot) {
                           const children = await greatGrandparentWorkspace.$get("childWorkspaces") as Workspace[];
-                          let allResolved = true;
+                          let allResolvedOrArchived = true;
                           for (const child of children) {
-                            if (!child.isCurrentlyResolved) {
-                              allResolved = false;
+                            if (!(child.isCurrentlyResolved || child.isArchived)) {
+                              allResolvedOrArchived = false;
                               break;
                             }
                           }
-                          if (allResolved) {
+                          if (allResolvedOrArchived) {
                             await greatGrandparentWorkspace.update({
                               isStale: true,
                               isNotStaleRelativeToUser: [],


### PR DESCRIPTION
Before, archived subquestions that hadn't been resolved were preventing parents from becoming stale again (where stale basically means eligible for rescheduling).