### PR TITLE
Store expansion status in URL

### DIFF
--- a/client/src/components/WorkspaceCard/index.tsx
+++ b/client/src/components/WorkspaceCard/index.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { compose } from "recompose";
 import { graphql } from "react-apollo";
 import { parse as parseQueryString } from "query-string";
+import * as _ from "lodash";
 import {
   ROOT_WORKSPACE_SUBTREE_QUERY,
   CHILD_WORKSPACE_SUBTREE_QUERY,
@@ -67,7 +68,9 @@ const optionsForSubtreeTimeSpentQuery = ({ workspaceId, isTopLevelOfCurrentTree 
 export class WorkspaceCardContainer extends React.PureComponent<any, any> {
   public render() {
     const queryParams = parseQueryString(window.location.search);
-    const isExpanded = queryParams.expanded === "true";
+    const { expanded, expand = "" } = queryParams;
+    const expandIds = expand.split(",").filter(param => param.length > 0);
+    const isExpanded = expanded === "true" || _.includes(expandIds, this.props.workspaceId);
 
     if (
       this.props.oracleModeQuery.oracleMode !== undefined


### PR DESCRIPTION
Solution for #331 

A new query string parameter `expand` is introduced which stores a comma-separated list of expanded workspace ids.

When a subtree is collapsed, a corresponding workspace id is removed from the URL.

When there are no expanded nodes, `expand` is removed completely from a query string.

URL is of the form:
`http://localhost:3000/workspaces/2487918d-7ddc-488b-937b-e0b90428e088/subtree?expand=e3cbf7d8-d001-4f7b-8f55-a9827da4f6ed,2487918d-7ddc-488b-937b-e0b90428e088`

**Potential improvements:**
- when a nested subtree is collapsed, remove ids of expanded children from the URL, not only the id of a tree that is being collapsed
- fetch a whole subtree with a single graphql query
- shorten ids in the URL. Storing whole UUIDs is not necessary and it might be enough to store 7-8 characters. The same mechanism employs git to shorten commit hashes. This would make the URL much shorter and easier to share.
- Updated `query-string` dependency to the latest version (`6.4.2`) to have an automated conversion to an array with `arrayFormat = "comma"` option . Right now the query string value is converted into an array manually. Upgrade to TypeScript 3 needed as query-string 6.4.2 uses keyworn `unknown`.
