### PR TITLE
Persist assignment through deploy

### DIFF
--- a/server/lib/scheduler/UserSchedule.ts
+++ b/server/lib/scheduler/UserSchedule.ts
@@ -85,7 +85,7 @@ class UserSchedule {
       userId: this.userId,
       workspace,
       startAtTimestamp,
-      endAtTimestamp: endAtTimestamp || Date.now(),
+      endAtTimestamp,
       isAlreadySavedToDb: true,
     });
 

--- a/server/lib/scheduler/index.ts
+++ b/server/lib/scheduler/index.ts
@@ -52,7 +52,7 @@ export async function createScheduler(experimentId) {
             startAtTimestamp: Number(a.dataValues.startAtTimestamp),
             endAtTimestamp: a.dataValues.endAtTimestamp
               ? Number(a.dataValues.endAtTimestamp)
-              : Date.now(),
+              : null,
           },
           workspace,
         };


### PR DESCRIPTION
When creating the in-memory scheduler for an experiment, the assignments in the database for that experiment are converted into in-memory objects. During this conversion process, any assignments in the database that lack an end time are converted into in-memory objects with the current time as their end time.

The original thought was that the assignments without an end time had probably been abandoned, and we didn’t want the newly created scheduler to refuse to assign other participants to these workspaces.

Deploying a change to production restarts the dyno and restarts all in-memory activity. So after a deployment to production, the in-memory schedulers get re-created as they are needed. 

It follows from everything I've said so far that: if a user is in the middle of an assignment during a deploy to production, the newly created scheduler for that experiment will consider that assignment as over, and inform the user that they are no longer assigned to that workspace.

This pull request changes the scheduler so that a newly created scheduler treats an assignment without an end time as still in process. It doesn’t assume the assignment is over. So deploying a change to production should not disrupt a user's assignment.