### PR TITLE
Judge-specific text display

### DIFF
--- a/client/src/pages/EpisodeShowPage/index.tsx
+++ b/client/src/pages/EpisodeShowPage/index.tsx
@@ -683,11 +683,11 @@ export class WorkspaceView extends React.Component<any, any> {
       !isOracleWorkspace &&
       doesRootWorkspaceScratchpadContainRelevantContent;
 
-    const judgeRegex = /(?<=<judge>)(.*)(?=<judge>)/;
+    const judgeRegex = /<judge>(.*)<\/judge>/;
     const judgeTextArray = judgeRegex.exec(
       listOfSlateNodesToText(_.get(rootWorkspaceScratchPad, "value"), false),
     );
-    const judgeText = judgeTextArray ? judgeTextArray[0] : null;
+    const judgeText = judgeTextArray ? judgeTextArray[1] : null;
 
     return (
       <div>

--- a/client/src/pages/EpisodeShowPage/index.tsx
+++ b/client/src/pages/EpisodeShowPage/index.tsx
@@ -48,6 +48,7 @@ import {
 
 import { ExpandAllPointersBtn } from "./ExpandAllPointersBtn";
 import { databaseJSONToValue } from "../../lib/slateParser";
+import { listOfSlateNodesToText } from "../../lib/slateParser";
 
 import {
   ORACLE_MODE_QUERY,
@@ -677,6 +678,17 @@ export class WorkspaceView extends React.Component<any, any> {
       ? this.getAvailablePointers(workspace, rootWorkspaceScratchPad)
       : this.getAvailablePointers(workspace);
 
+    const shouldShowJudgeTextFromScratchpad =
+      hasParent &&
+      !isOracleWorkspace &&
+      doesRootWorkspaceScratchpadContainRelevantContent;
+
+    const judgeRegex = /(?<=<judge>)(.*)(?=<judge>)/;
+    const judgeTextArray = judgeRegex.exec(
+      listOfSlateNodesToText(_.get(rootWorkspaceScratchPad, "value"), false),
+    );
+    const judgeText = judgeTextArray ? judgeTextArray[0] : null;
+
     return (
       <div>
         <Helmet>
@@ -755,7 +767,9 @@ export class WorkspaceView extends React.Component<any, any> {
                           {isWorkspacePartOfOracleExperiment && (
                             <DepthDisplay
                               depth={workspace.depth}
-                              depthLimit={workspace.rootWorkspace.tree.depthLimit}
+                              depthLimit={
+                                workspace.rootWorkspace.tree.depthLimit
+                              }
                             />
                           )}
                           {hasIOConstraints &&
@@ -823,6 +837,17 @@ export class WorkspaceView extends React.Component<any, any> {
                                 availablePointers={availablePointers}
                                 {...rootWorkspaceScratchpadProps}
                               />
+                            </div>
+                          )}
+                          {shouldShowJudgeTextFromScratchpad && (
+                            <div
+                              style={{
+                                fontSize: "18px",
+                                marginBottom: "20px",
+                                minWidth: "550px",
+                              }}
+                            >
+                              <p>{judgeText}</p>
                             </div>
                           )}
                           <BlockEditor


### PR DESCRIPTION
closes #736

Wrap scratchpad text in `<judge> judge text here </judge>` for judge-specific text. Experts will be able to see the judge text, but judges wont be able to see anything outside the judge text.